### PR TITLE
Support of Scala 2.13.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,18 @@
 
 val jacksonVersion = "2.9.9"
-val playJsonVersion = "2.7.3"
+val playJsonVersion = "2.7.4"
 val playLib = "com.typesafe.play" %% "play-json" % playJsonVersion
 
 lazy val commonSettings = Seq(
     organization := "reug",
     scalaVersion := "2.12.8",
-    crossScalaVersions := Seq("2.11.12", scalaVersion.value),
+    crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.0"),
 
     libraryDependencies ++= Seq(
         "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
         "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
         "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
-        "org.scalatest" %% "scalatest" % "3.0.5" % Test
+        "org.scalatest" %% "scalatest" % "3.0.8" % Test
     ),
     scalacOptions := Seq(
         "-target:jvm-1.8",

--- a/core/src/main/scala/reug/scalikejackson/ScalaJackson.scala
+++ b/core/src/main/scala/reug/scalikejackson/ScalaJackson.scala
@@ -18,7 +18,7 @@ import scala.util.Try
 
 sealed trait ScalaJacksonParser[T] {
     self =>
-    private[scalikejackson] val mappers: mutable.MutableList[ObjectMapper] = mutable.MutableList[ObjectMapper]()
+    private[scalikejackson] val mappers: mutable.ArrayBuffer[ObjectMapper] = mutable.ArrayBuffer[ObjectMapper]()
 
     protected def registerSerializer[U: ClassTag](ser: StdSerializer[U]): this.type = {
         val clazz = implicitly[ClassTag[U]].runtimeClass.asInstanceOf[Class[U]]

--- a/core/src/main/scala/reug/scalikejackson/ScalaJacksonImpl.scala
+++ b/core/src/main/scala/reug/scalikejackson/ScalaJacksonImpl.scala
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.{NullNode, ObjectNode}
 
 import scala.annotation.implicitNotFound
 import scala.collection.JavaConverters._
-import scala.collection.breakOut
 import scala.language.postfixOps
 import scala.reflect.ClassTag
 import scala.util.Try
@@ -56,9 +55,9 @@ object ScalaJacksonImpl {
 
         def asMap[T: ScalaJacksonReader : ClassTag]: Map[String, T] = {
             if (node.isObject) {
-                node.fields().asScala.toSeq.map {
+                node.fields().asScala.map {
                     el => (el.getKey, el.getValue.as[T])
-                }(breakOut)
+                }.toMap
             } else {
                 throw new UnsupportedOperationException("JsonNode is not an object")
             }
@@ -92,7 +91,7 @@ object ScalaJacksonImpl {
         }
 
         def \\(key: String): Seq[JsonNode] = {
-            node.findValues(key).asScala
+            node.findValues(key).asScala.toList
         }
     }
 


### PR DESCRIPTION
Initial support of Scala 2.13.x that can close #10 after release

It still has a lot of warnings in places that can be revised for more efficient implementations.